### PR TITLE
Increase Flutter support and flutter_lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,34 @@
 # flutter_nord_theme
 
+## 3.0.0
+
+- Increase Flutter compatibility
+- Update theme to Material 3
+
 ## 2.1.0
-* New theme properties:
-  * Theme for FloatingActionButon.
-  * Each theme is now based on a ColorScheme.
-* Meta:
-  * Update package description.
-  * The documentation now covers all the elements of the public API.
+
+- New theme properties:
+  - Theme for FloatingActionButton.
+  - Each theme is now based on a ColorScheme.
+- Meta:
+  - Update package description.
+  - The documentation now covers all the elements of the public API.
 
 ## 2.0.2
-* Fixes
-  * Label color for navigation theme
-  * Card background color for light theme
-  * Divider color for light theme
+
+- Fixes
+  - Label color for navigation theme
+  - Card background color for light theme
+  - Divider color for light theme
 
 ## 2.0.1
-* Added a theme for NavigationRail
+
+- Added a theme for NavigationRail
 
 ## 2.0.0
-* Migrating to null safety.
+
+- Migrating to null safety.
 
 ## 1.0.0
-* First working version, usable in development: a light theme and a dark theme, not customizables.
+
+- First working version, usable in development: a light theme and a dark theme, not customizables.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/example/full_example/lib/buttons.dart
+++ b/example/full_example/lib/buttons.dart
@@ -1,27 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_nord_theme/flutter_nord_theme.dart';
 
-final List<Widget> buttons = [
+final buttons = <Widget>[
   TextButton(
-    child: Text('TextButton'),
-    onPressed: () => null,
+    child: const Text('TextButton'),
+    onPressed: () {},
   ),
   ElevatedButton(
-    child: Text('ElevatedButton'),
-    onPressed: () => null,
+    child: const Text('ElevatedButton'),
+    onPressed: () {},
   ),
   OutlinedButton(
-    child: Text('OutlinedButton'),
-    onPressed: () => null,
+    child: const Text('OutlinedButton'),
+    onPressed: () {},
   ),
   ElevatedButton(
-    child: Text('Custom button'),
     style: ElevatedButton.styleFrom(
-      primary: NordColors.aurora.red,
+      backgroundColor: NordColors.aurora.red,
     ),
-    onPressed: () => null,
+    onPressed: () {},
+    child: const Text('Custom button'),
   ),
-  TextButton(child: Text('TextButton'), onPressed: null),
-  ElevatedButton(child: Text('ElevatedButton'), onPressed: null),
-  OutlinedButton(child: Text('OutlinedButton'), onPressed: null),
+  const TextButton(onPressed: null, child: Text('TextButton')),
+  const ElevatedButton(onPressed: null, child: Text('ElevatedButton')),
+  const OutlinedButton(onPressed: null, child: Text('OutlinedButton')),
 ];

--- a/example/full_example/lib/main.dart
+++ b/example/full_example/lib/main.dart
@@ -1,19 +1,20 @@
 import 'package:flutter/material.dart';
 
+import 'buttons.dart';
+import 'switches.dart';
+import 'texts.dart';
 import 'theme.dart';
 import 'theme_switch_list_tile.dart';
 
-import 'texts.dart';
-import 'buttons.dart';
-import 'switches.dart';
-
 void main() {
-  runApp(MyApp());
+  runApp(const MyApp());
 }
 
 class MyApp extends StatefulWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
-  _MyAppState createState() => _MyAppState();
+  State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
@@ -30,8 +31,8 @@ class _MyAppState extends State<MyApp> {
         debugShowCheckedModeBanner: false,
         theme: theme.currentThemeData(),
         home: Scaffold(
-          appBar: AppBar(title: Text('Demo app')),
-          drawer: Drawer(child: ThemeSwitchListTile()),
+          appBar: AppBar(title: const Text('Demo app')),
+          drawer: const Drawer(child: ThemeSwitchListTile()),
           body: Padding(
             padding: const EdgeInsets.all(20.0),
             child: Wrap(

--- a/example/full_example/lib/switches.dart
+++ b/example/full_example/lib/switches.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 
 final List<Widget> switches = [
-  ToggleableSwitch(),
-  Switch(value: false, onChanged: (_) => null),
-  Switch(value: false, onChanged: null),
+  const ToggleableSwitch(),
+  Switch(value: false, onChanged: (_) {}),
+  const Switch(value: false, onChanged: null),
 ];
 
 class ToggleableSwitch extends StatefulWidget {
+  const ToggleableSwitch({Key? key}) : super(key: key);
+
   @override
-  _ToggleableSwitchState createState() => _ToggleableSwitchState();
+  State<ToggleableSwitch> createState() => _ToggleableSwitchState();
 }
 
 class _ToggleableSwitchState extends State<ToggleableSwitch> {

--- a/example/full_example/lib/texts.dart
+++ b/example/full_example/lib/texts.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-final texts = [
+const texts = <Widget>[
   Text('Example text.'),
   SelectableText('Selectable text.'),
 ];

--- a/example/full_example/lib/theme_switch_list_tile.dart
+++ b/example/full_example/lib/theme_switch_list_tile.dart
@@ -4,8 +4,10 @@ import 'package:flutter_nord_theme/flutter_nord_theme.dart';
 import 'theme.dart';
 
 class ThemeSwitchListTile extends StatefulWidget {
+  const ThemeSwitchListTile({Key? key}) : super(key: key);
+
   @override
-  _ThemeSwitchListTileState createState() => _ThemeSwitchListTileState();
+  State<ThemeSwitchListTile> createState() => _ThemeSwitchListTileState();
 }
 
 class _ThemeSwitchListTileState extends State<ThemeSwitchListTile> {
@@ -13,7 +15,7 @@ class _ThemeSwitchListTileState extends State<ThemeSwitchListTile> {
   Widget build(BuildContext context) {
     final value = theme.currentMode() == ThemeMode.dark;
     return SwitchListTile(
-      title: Text('Switch theme'),
+      title: const Text('Switch theme'),
       value: value,
       secondary: Icon(
         value ? Icons.palette : Icons.palette_outlined,

--- a/example/simple_example.dart
+++ b/example/simple_example.dart
@@ -7,18 +7,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_nord_theme/flutter_nord_theme.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) => MaterialApp(
         themeMode: ThemeMode.light, // Or [ThemeMode.dark]
         theme: NordTheme.light(),
         darkTheme: NordTheme.dark(),
         home: Scaffold(
-          appBar: AppBar(title: Text('Title')),
-          body: Center(child: Text('Example text.')),
+          appBar: AppBar(title: const Text('Title')),
+          body: const Center(child: Text('Example text.')),
         ),
       );
 }

--- a/lib/flutter_nord_theme.dart
+++ b/lib/flutter_nord_theme.dart
@@ -1,5 +1,5 @@
 /// An arctic, north-bluish theme for Flutter, based on the Nord theme.
 library flutter_nord_theme;
 
-export 'src/themes/theme.dart' show NordTheme;
 export 'src/colors/colors.dart' show NordColors;
+export 'src/themes/theme.dart' show NordTheme;

--- a/lib/src/colors/colors.dart
+++ b/lib/src/colors/colors.dart
@@ -33,51 +33,51 @@ abstract class NordColors {
   static const aurora = NordAurora();
 
   /// The origin color of the Polar Night palette.
-  static const $0 = const Color(NordColorCodes.$0);
+  static const $0 = Color(NordColorCodes.$0);
 
   /// A brighter shade color based on [$0].
-  static const $1 = const Color(NordColorCodes.$1);
+  static const $1 = Color(NordColorCodes.$1);
 
   /// An even more brighter shade color of [$0]].
-  static const $2 = const Color(NordColorCodes.$2);
+  static const $2 = Color(NordColorCodes.$2);
 
   /// The brightest shade color based on [$0].
-  static const $3 = const Color(NordColorCodes.$3);
+  static const $3 = Color(NordColorCodes.$3);
 
   /// The origin color or the Snow Storm palette.
-  static const $4 = const Color(NordColorCodes.$4);
+  static const $4 = Color(NordColorCodes.$4);
 
   /// A brighter shade color of [$4].
-  static const $5 = const Color(NordColorCodes.$5);
+  static const $5 = Color(NordColorCodes.$5);
 
   /// The brightest shade color based on [$4].
-  static const $6 = const Color(NordColorCodes.$6);
+  static const $6 = Color(NordColorCodes.$6);
 
   /// A calm and highly contrasted color reminiscent of frozen polar water.
-  static const $7 = const Color(NordColorCodes.$7);
+  static const $7 = Color(NordColorCodes.$7);
 
   /// The bright and shiny primary accent color reminiscent of pure and clear
   /// ice.
-  static const $8 = const Color(NordColorCodes.$8);
+  static const $8 = Color(NordColorCodes.$8);
 
   /// A more darkened and less saturated color reminiscent of arctic waters.
-  static const $9 = const Color(NordColorCodes.$9);
+  static const $9 = Color(NordColorCodes.$9);
 
   /// A dark and intensive color reminiscent of the deep arctic ocean.
-  static const $10 = const Color(NordColorCodes.$10);
+  static const $10 = Color(NordColorCodes.$10);
 
   /// A vermilion, yet soothing color.
-  static const $11 = const Color(NordColorCodes.$11);
+  static const $11 = Color(NordColorCodes.$11);
 
   /// A saturated, imposing orange color.
-  static const $12 = const Color(NordColorCodes.$12);
+  static const $12 = Color(NordColorCodes.$12);
 
   /// A calming yellow color.
-  static const $13 = const Color(NordColorCodes.$13);
+  static const $13 = Color(NordColorCodes.$13);
 
   /// A nice, neither too bright nor too dark, green color.
-  static const $14 = const Color(NordColorCodes.$14);
+  static const $14 = Color(NordColorCodes.$14);
 
   /// A dark, dull violet color.
-  static const $15 = const Color(NordColorCodes.$15);
+  static const $15 = Color(NordColorCodes.$15);
 }

--- a/lib/src/themes/roles/dark.dart
+++ b/lib/src/themes/roles/dark.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-
 import 'package:flutter_nord_theme/flutter_nord_theme.dart';
+
 import 'roles.dart';
 
 class NordDarkColorRoles extends NordColorRoles {

--- a/lib/src/themes/roles/light.dart
+++ b/lib/src/themes/roles/light.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-
 import 'package:flutter_nord_theme/flutter_nord_theme.dart';
+
 import 'roles.dart';
 
 class NordLightColorRoles extends NordColorRoles {

--- a/lib/src/themes/roles/roles.dart
+++ b/lib/src/themes/roles/roles.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-
 import 'package:flutter_nord_theme/flutter_nord_theme.dart';
+
 import 'light.dart';
 
 /// This class describes the role of each color.
@@ -22,9 +22,9 @@ abstract class NordColorRoles {
   /// in theory, all the other [ThemeData] properties are just overrides.
   ColorScheme get colorScheme => ColorScheme(
         primary: primary,
-        primaryVariant: primary,
+        primaryContainer: primary,
         secondary: secondary,
-        secondaryVariant: secondary,
+        secondaryContainer: secondary,
         surface: card,
         background: background,
         error: error,
@@ -70,7 +70,7 @@ abstract class NordColorRoles {
   Color get splash;
 
   /// The color of shadows (e.g. for [Card] widgets).
-  final Color shadow = Color(0x590f1115);
+  Color get shadow => const Color(0x590f1115);
 
   /// A color that contrasts with [primary], e.g. used as the remaining part of
   /// a progress bar.
@@ -141,8 +141,9 @@ abstract class NordColorRoles {
         }),
         backgroundColor: MaterialStateProperty.all<Color>(Colors.transparent),
         overlayColor: MaterialStateProperty.resolveWith<Color?>((states) {
-          if (states.contains(MaterialState.hovered))
+          if (states.contains(MaterialState.hovered)) {
             return button.withOpacity(0.04);
+          }
           if (states.contains(MaterialState.focused) ||
               states.contains(MaterialState.pressed)) {
             return button.withOpacity(0.12);
@@ -192,12 +193,12 @@ abstract class NordColorRoles {
   NavigationRailThemeData? get navigationRail {
     return NavigationRailThemeData(
       backgroundColor: bottomAppBar,
-      unselectedLabelTextStyle: TextStyle(fontSize: 10),
+      unselectedLabelTextStyle: const TextStyle(fontSize: 10),
       selectedLabelTextStyle: TextStyle(
         fontSize: 10,
         color: primary,
       ),
-      unselectedIconTheme: IconThemeData(),
+      unselectedIconTheme: const IconThemeData(),
       selectedIconTheme: IconThemeData(color: primary),
     );
   }

--- a/lib/src/themes/theme.dart
+++ b/lib/src/themes/theme.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
-import 'roles/roles.dart';
 import 'roles/dark.dart';
 import 'roles/light.dart';
+import 'roles/roles.dart';
 
 /// Provides a [light] and a [dark] theme ([ThemeData]).
 ///
@@ -22,26 +22,43 @@ abstract class NordTheme {
 
   static ThemeData _merge(ThemeData original, NordColorRoles roles) =>
       original.copyWith(
-        colorScheme: roles.colorScheme,
         brightness: roles.brightness,
         primaryColor: roles.primary,
-        accentColor: roles.accent,
         canvasColor: roles.canvas,
         shadowColor: roles.shadow,
         scaffoldBackgroundColor: roles.scaffoldBackground,
-        bottomAppBarColor: roles.bottomAppBar,
         cardColor: roles.card,
         dividerColor: roles.divider,
-        toggleableActiveColor: roles.toggleableActive,
+        radioTheme: RadioThemeData(
+          fillColor: MaterialStateProperty.resolveWith<Color?>(
+              (Set<MaterialState> states) {
+            if (states.contains(MaterialState.disabled)) {
+              return null;
+            }
+            if (states.contains(MaterialState.selected)) {
+              return roles.toggleableActive;
+            }
+            return null;
+          }),
+        ),
+        checkboxTheme: CheckboxThemeData(
+          fillColor: MaterialStateProperty.resolveWith<Color?>(
+              (Set<MaterialState> states) {
+            if (states.contains(MaterialState.disabled)) {
+              return null;
+            }
+            if (states.contains(MaterialState.selected)) {
+              return roles.toggleableActive;
+            }
+            return null;
+          }),
+        ),
         focusColor: roles.focus,
         hoverColor: roles.hover,
         highlightColor: roles.highlight,
         splashColor: roles.splash,
-        errorColor: roles.error,
-        selectedRowColor: roles.selectedRow,
         unselectedWidgetColor: roles.unselectedWidget,
         disabledColor: roles.disabled,
-        buttonColor: roles.button,
         textSelectionTheme: roles.textSelection,
         textButtonTheme: TextButtonThemeData(style: roles.textButton),
         elevatedButtonTheme:
@@ -51,5 +68,9 @@ abstract class NordTheme {
         switchTheme: roles.switchTheme,
         navigationRailTheme: roles.navigationRail,
         floatingActionButtonTheme: roles.floatingActionButton,
+        bottomAppBarTheme: BottomAppBarTheme(color: roles.bottomAppBar),
+        colorScheme: roles.colorScheme
+            .copyWith(secondary: roles.accent)
+            .copyWith(error: roles.error),
       );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,82 +5,108 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      sha256: e2a421b7e59244faef694ba7b30562e489c2b489866e505074eb005cd7060db7
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.16"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -90,58 +116,66 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.19"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
+  flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: flutter_nord_theme
 description: An arctic, north-bluish theme for Flutter, based on the Nord theme.
-version: 2.1.0
+version: 3.0.0
 repository: https://github.com/Firefnix/flutter-nord-theme
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
-  flutter: '>=2.0.0'
+  sdk: ">=2.12.0 <4.0.0"
+  flutter: ">=2.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,14 +4,15 @@ version: 2.1.0
 repository: https://github.com/Firefnix/flutter-nord-theme
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=1.17.0'
+  sdk: '>=2.12.0 <4.0.0'
+  flutter: '>=2.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
 
 dev_dependencies:
+  flutter_lints: ^3.0.1
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
This PR updates Flutter compatibility to accept current versions (`3.16`) and adds the recommend `flutter_lints.`
The theme is also updated to Material 3 (`useMaterial3`), so I increased the version to `3.0.0`.